### PR TITLE
Add directory argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ LABEL com.github.actions.color="gray-dark"
 
 RUN npm install -g appcenter-cli
 
+ARG directory
+ENV INPUT_DIRECTORY=directory
+
 COPY LICENSE README.md /
 COPY "entrypoint.sh" "/entrypoint.sh"
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This Action for [appcenter codepush](https://github.com/microsoft/appcenter-cli)
 
 ## Inputs
 
+* `directory` - Directory from which to run the command
 * `args` - **Required**. This is the arguments you want to use for the `appcenter` cli
 
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# Credit to Author
+This project was forked from https://github.com/NishanthShankar/codepush-action and updated to use a working directory argument. This was needed to make the action work for a monorepo environment.
+
 # GitHub Actions for Firebase
 
 This Action for [appcenter codepush](https://github.com/microsoft/appcenter-cli) enables arbitrary actions with the `appcenter` command-line client.

--- a/action.yaml
+++ b/action.yaml
@@ -7,8 +7,9 @@ branding:
 runs:
   using: 'docker'
   image: 'Dockerfile'
-  with:
-    build-args: directory: ${{ inputs.directory }}
+  args:
+    - ${{ inputs.args }}
+    - ${{ inputs.directory }}
 inputs:
   directory:
     description: 'Directory from which to run the command'

--- a/action.yaml
+++ b/action.yaml
@@ -7,6 +7,8 @@ branding:
 runs:
   using: 'docker'
   image: 'Dockerfile'
+  with:
+    build-args: directory: ${{ inputs.directory }}
 inputs:
   directory:
     description: 'Directory from which to run the command'

--- a/action.yaml
+++ b/action.yaml
@@ -7,3 +7,6 @@ branding:
 runs:
   using: 'docker'
   image: 'Dockerfile'
+inputs:
+  directory:
+    description: 'Directory from which to run the command'

--- a/action.yaml
+++ b/action.yaml
@@ -1,6 +1,6 @@
-name: 'GitHub Action for Codepush'
-author: 'Nishanth Shankar'
-description: 'Wraps the appcenter CLI to enable common commands.'
+name: 'Freeplay - GitHub Action for Codepush'
+author: 'Jacob Turner'
+description: 'Wraps the appcenter CLI to enable common commands. Supports mono repos.'
 branding:
   icon: 'package'
   color: 'gray-dark'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,7 @@ if [ -z $directory ]; then
 else
   echo "Input directory provided:"
   echo "$directory"
-  cd "$(dirname "$0")/$directory"
+  cd "$(dirname "$0")$directory"
   cd "$directory"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,11 +3,17 @@
 set -e
 
 if [ -z "${INPUT_directory}" ]; then
+  echo "No input directory provided"
   # No input directory provided
   cd "$(dirname "$0")/.."
 else
+  echo "Input directory provided:"
+  echo "${INPUT_directory}"
   cd "${INPUT_directory}"
 fi
+
+echo "PWD:"
+echo $PWD
 
 if [ -z "$APPCENTER_ACCESS_TOKEN" ]; then
     echo "APPCENTER_ACCESS_TOKEN is required to run commands with the appcenter cli"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,13 @@
 
 set -e
 
+if [[ -z "${INPUT_directory}" ]]; then
+  # No input directory provided
+  cd "$(dirname "$0")/.."
+else
+  cd "${INPUT_directory}"
+fi
+
 if [ -z "$APPCENTER_ACCESS_TOKEN" ]; then
     echo "APPCENTER_ACCESS_TOKEN is required to run commands with the appcenter cli"
     exit 126

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,14 +4,7 @@ set -e
 args=$1
 directory=$2
 
-echo "PWD:"
-echo $PWD
-
-echo "LS:"
-ls
-
 if [ -z $directory ]; then
-  echo "No input directory provided"
   # No input directory provided
   cd "$(dirname "$0")/.."
 else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [[ -z "${INPUT_directory}" ]]; then
+if [ -z "${INPUT_directory}" ]; then
   # No input directory provided
   cd "$(dirname "$0")/.."
 else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,7 +17,7 @@ if [ -z $directory ]; then
 else
   echo "Input directory provided:"
   echo "$directory"
-  cd "$(dirname "$0")$directory"
+  cd "$directory"
 fi
 
 if [ -z "$APPCENTER_ACCESS_TOKEN" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,15 +1,18 @@
 #!/bin/sh -l
 
 set -e
+args=$1
+directory=$2
 
-if [ -z "${INPUT_DIRECTORY}" ]; then
+if [ -z $directory ]; then
   echo "No input directory provided"
   # No input directory provided
   cd "$(dirname "$0")/.."
 else
   echo "Input directory provided:"
-  echo "${INPUT_DIRECTORY}"
-  cd "${INPUT_DIRECTORY}"
+  echo "$directory"
+  cd "$(dirname "$0")/$directory"
+  cd "$directory"
 fi
 
 echo "PWD:"
@@ -21,4 +24,4 @@ if [ -z "$APPCENTER_ACCESS_TOKEN" ]; then
 fi
 
 
-sh -c "appcenter codepush $*"
+sh -c "appcenter codepush $args"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,7 +18,6 @@ else
   echo "Input directory provided:"
   echo "$directory"
   cd "$(dirname "$0")$directory"
-  cd "$directory"
 fi
 
 if [ -z "$APPCENTER_ACCESS_TOKEN" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,12 @@ set -e
 args=$1
 directory=$2
 
+echo "PWD:"
+echo $PWD
+
+echo "LS:"
+ls
+
 if [ -z $directory ]; then
   echo "No input directory provided"
   # No input directory provided
@@ -14,9 +20,6 @@ else
   cd "$(dirname "$0")$directory"
   cd "$directory"
 fi
-
-echo "PWD:"
-echo $PWD
 
 if [ -z "$APPCENTER_ACCESS_TOKEN" ]; then
     echo "APPCENTER_ACCESS_TOKEN is required to run commands with the appcenter cli"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,14 +2,14 @@
 
 set -e
 
-if [ -z "${INPUT_directory}" ]; then
+if [ -z "${INPUT_DIRECTORY}" ]; then
   echo "No input directory provided"
   # No input directory provided
   cd "$(dirname "$0")/.."
 else
   echo "Input directory provided:"
-  echo "${INPUT_directory}"
-  cd "${INPUT_directory}"
+  echo "${INPUT_DIRECTORY}"
+  cd "${INPUT_DIRECTORY}"
 fi
 
 echo "PWD:"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -4,8 +4,12 @@
 # Exit if any subcommand fails
 set -e
 
-# Ensure we're always running from the project root
-cd "$(dirname "$0")/.."
+if [[ -z "${INPUT_directory}" ]]; then
+  # No input directory provided
+  cd "$(dirname "$0")/.."
+else
+  cd "${INPUT_directory}"
+fi
 
 if [ -f "Brewfile" ] && [ "$(uname -s)" = "Darwin" ]; then
   brew bundle check >/dev/null 2>&1  || {

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -4,12 +4,8 @@
 # Exit if any subcommand fails
 set -e
 
-if [[ -z "${INPUT_directory}" ]]; then
-  # No input directory provided
-  cd "$(dirname "$0")/.."
-else
-  cd "${INPUT_directory}"
-fi
+# No input directory provided
+cd "$(dirname "$0")/.."
 
 if [ -f "Brewfile" ] && [ "$(uname -s)" = "Darwin" ]; then
   brew bundle check >/dev/null 2>&1  || {


### PR DESCRIPTION
Hey @NishanthShankar!  Thanks for creating this cool little action - we've put it to good use!

We have recently migrated to a mono-repo, and need to run the release-react command in a directory that isn't root.  I initially tried using Github Actions' `working-directory` option, but that does not work in conjunction with `uses` or `with`  I ended up forking this action and making it work for our use-case - this is what I came up with.

I'd love to get this merged back upstream if you find this would be an acceptable and valuable addition.  If that's the case, let me know and I'll clean up this PR and remove irrelevant changes.  I'm also not super experienced in bash, so if you have a cleaner approach, I'm all ears!

If this is not an API you want to add, that's fine - I'm happy to continue using our fork.

Thanks!